### PR TITLE
fix: disable cache on API gateway stage

### DIFF
--- a/infra/modules/api-gateway/api-gateway.tf
+++ b/infra/modules/api-gateway/api-gateway.tf
@@ -27,6 +27,7 @@ resource "aws_api_gateway_deployment" "api_deployment" {
 }
 
 resource "aws_api_gateway_stage" "api_stage" {
+  # checkov:skip=CKV2_AWS_29:WAF not needed for non-prod use
   deployment_id = aws_api_gateway_deployment.api_deployment.id
   rest_api_id   = aws_api_gateway_rest_api.api_gateway.id
   stage_name    = "dev"
@@ -66,9 +67,7 @@ resource "aws_api_gateway_method_settings" "api_gateway_method_settings" {
   method_path = "*/*"
 
   settings {
-    caching_enabled      = true
-    cache_ttl_in_seconds = "3600" # 1 hour
-
+    caching_enabled = false
     metrics_enabled = true
     logging_level   = "ERROR"
   }


### PR DESCRIPTION
This was breaking the `/{proxy+}` integration as it was treating all requests as the same path.